### PR TITLE
OP-10373 - Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Syntax notes:
+# - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+# - The syntax matches most of the same rules as .gitignore files
+# - Each line is a case-sensitive file pattern followed by one or more owners with Write access to the repo e.g.
+#   * @OnboardRS/black       # Team with default ownership over everything (teams are preferred over individuals)
+#   * @onboard-service-dev   # User with default ownership over everything
+# - Order is important; the last matching pattern takes the most precedence
+
+# The following teams will be the default code owners for everything in the repo. Unless a later match takes
+# precedence, the following owners will automatically be requested for review when a PR is opened. Draft PRs do
+# not automatically request reviews until they are marked as Ready for Review. If the repo's Branch Protection
+# Rules require a review from a code owner, at least one owner must sign off before a PR can be merged.
+* @OnboardRS/black @OnboardRS/gold @OnboardRS/green @OnboardRS/purple @OnboardRS/red


### PR DESCRIPTION
This PR creates a CODEOWNERS file with the new team(s) assigned during the GitHub cleanup project.

For most repos, only one team was granted permissions on the [Collaborators and Teams](https://github.com/OnboardRS/github-action-code-quality/settings/access) page.  If there should be a different set of owners for the repo, please update the teams granted permissions and modify the CODEOWNERS before merging.  Individuals can be listed in the CODEOWNERS file but teams are preferred.

Please review the CODEOWNERS file in this PR and the assigned teams on the [Collaborators and Teams](https://github.com/OnboardRS/github-action-code-quality/settings/access) page of the repo then merge at your earliest convenience.  No changes need to be deployed.